### PR TITLE
add way to provide list of output produced

### DIFF
--- a/pkg/cmd/multi-operator-manager/sample-operator/produces/apply_configuration_command.go
+++ b/pkg/cmd/multi-operator-manager/sample-operator/produces/apply_configuration_command.go
@@ -1,0 +1,12 @@
+package applyconfiguration
+
+import (
+	"github.com/openshift/multi-operator-manager/pkg/library/libraryproduces"
+	"github.com/openshift/multi-operator-manager/pkg/sampleoperator/sampleproduces"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+)
+
+func NewSampleOperatorProducesCommand(streams genericiooptions.IOStreams) *cobra.Command {
+	return libraryproduces.NewProducesCommand(sampleproduces.SampleRunApplyProduces, streams)
+}

--- a/pkg/library/libraryproduces/command.go
+++ b/pkg/library/libraryproduces/command.go
@@ -1,0 +1,74 @@
+package libraryproduces
+
+import (
+	"context"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+)
+
+type ProducesFunc func(ctx context.Context) (*ProducedResources, error)
+
+func NewProducesCommand(producesFn ProducesFunc, streams genericiooptions.IOStreams) *cobra.Command {
+	return newProducesCommand(producesFn, streams)
+}
+
+type producesFlags struct {
+	producesFn ProducesFunc
+
+	streams genericiooptions.IOStreams
+}
+
+func newProducesFlags(streams genericiooptions.IOStreams) *producesFlags {
+	return &producesFlags{
+		streams: streams,
+	}
+}
+
+func newProducesCommand(producesFn ProducesFunc, streams genericiooptions.IOStreams) *cobra.Command {
+	f := newProducesFlags(streams)
+	f.producesFn = producesFn
+
+	cmd := &cobra.Command{
+		Use:   "produces",
+		Short: "Operator produces command.",
+
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			if err := f.Validate(); err != nil {
+				return err
+			}
+			o, err := f.ToOptions(ctx)
+			if err != nil {
+				return err
+			}
+			if err := o.Run(ctx); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	f.BindFlags(cmd.Flags())
+
+	return cmd
+}
+
+func (f *producesFlags) BindFlags(flags *pflag.FlagSet) {
+}
+
+func (f *producesFlags) Validate() error {
+	return nil
+}
+
+func (f *producesFlags) ToOptions(ctx context.Context) (*producesOptions, error) {
+	return newApplyConfigurationOptions(
+			f.producesFn,
+			f.streams,
+		),
+		nil
+}

--- a/pkg/library/libraryproduces/options.go
+++ b/pkg/library/libraryproduces/options.go
@@ -1,0 +1,39 @@
+package libraryproduces
+
+import (
+	"context"
+	"fmt"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"sigs.k8s.io/yaml"
+)
+
+type producesOptions struct {
+	producesFn ProducesFunc
+
+	streams genericiooptions.IOStreams
+}
+
+func newApplyConfigurationOptions(producesFn ProducesFunc, streams genericiooptions.IOStreams) *producesOptions {
+	return &producesOptions{
+		producesFn: producesFn,
+		streams:    streams,
+	}
+}
+
+func (o *producesOptions) Run(ctx context.Context) error {
+	result, err := o.producesFn(ctx)
+	if err != nil {
+		return err
+	}
+
+	producesYaml, err := yaml.Marshal(result)
+	if err != nil {
+		return err
+	}
+
+	if _, err := fmt.Fprint(o.streams.Out, string(producesYaml)); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/library/libraryproduces/types.go
+++ b/pkg/library/libraryproduces/types.go
@@ -1,0 +1,29 @@
+package libraryproduces
+
+type ProducedResources struct {
+	ConfigurationServerResources ResourceList `json:"configurationServerResources"`
+	ManagementServerResources    ResourceList `json:"managementServerResources"`
+	GuestServerResources         ResourceList `json:"guestServerResources"`
+}
+
+type ResourceList struct {
+	ExactResources []ExactResource `json:"exactResources"`
+
+	// TODO I bet this covers 95% of what we need, but maybe we need label selector.
+	// I'm a solid -1 on "pattern" based selection. We select in kube based on label selectors.
+}
+
+type ExactResource struct {
+	ResourceTypeIdentifier `json:",inline"`
+
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+}
+
+type ResourceTypeIdentifier struct {
+	Group string `json:"group"`
+	// version is very important because it must match the version of serialization that your operator expects.
+	// All Group,Resource tuples must use the same Version.
+	Version  string `json:"version"`
+	Resource string `json:"resource"`
+}

--- a/pkg/sampleoperator/sampleproduces/sample_apply_configuration.go
+++ b/pkg/sampleoperator/sampleproduces/sample_apply_configuration.go
@@ -1,0 +1,39 @@
+package sampleproduces
+
+import (
+	"context"
+	"github.com/openshift/multi-operator-manager/pkg/library/libraryproduces"
+)
+
+func SampleRunApplyProduces(ctx context.Context) (*libraryproduces.ProducedResources, error) {
+	// TODO probably make this a yaml file directly?  I don't know, it's not too bad like this.
+	return &libraryproduces.ProducedResources{
+		ConfigurationServerResources: libraryproduces.ResourceList{},
+		ManagementServerResources: libraryproduces.ResourceList{
+			ExactResources: []libraryproduces.ExactResource{
+				{
+					ResourceTypeIdentifier: libraryproduces.ResourceTypeIdentifier{
+						Group:    "config.openshift.io",
+						Version:  "v1",
+						Resource: "ingresses",
+					},
+					Namespace: "",
+					Name:      "cluster",
+				},
+			},
+		},
+		GuestServerResources: libraryproduces.ResourceList{
+			ExactResources: []libraryproduces.ExactResource{
+				{
+					ResourceTypeIdentifier: libraryproduces.ResourceTypeIdentifier{
+						Group:    "oauth.openshift.io",
+						Version:  "v1",
+						Resource: "oauthclients",
+					},
+					Namespace: "",
+					Name:      "openshift-browser-client",
+				},
+			},
+		},
+	}, nil
+}


### PR DESCRIPTION
This forces consideration of all data we expect to write *and* gives us a way to separate which things are configuration versus management versus guest in a structured way.