### PR TITLE
API-1835: write output even when there are errors

### DIFF
--- a/pkg/library/libraryapplyconfiguration/options.go
+++ b/pkg/library/libraryapplyconfiguration/options.go
@@ -2,6 +2,7 @@ package libraryapplyconfiguration
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 )
@@ -30,17 +31,18 @@ func (o *applyConfigurationOptions) Run(ctx context.Context) error {
 		return fmt.Errorf("unable to create output directory %q:%v", o.OutputDirectory, err)
 	}
 
+	errs := []error{}
 	result, err := o.ApplyConfigurationFn(ctx, o.Input)
 	if err != nil {
-		return err
+		errs = append(errs, err)
 	}
 	if err := ValidateAllDesiredMutationsGetter(result); err != nil {
-		return err
+		errs = append(errs, err)
 	}
 
 	if err := WriteApplyConfiguration(result, o.OutputDirectory); err != nil {
-		return err
+		errs = append(errs, err)
 	}
 
-	return nil
+	return errors.Join(errs...)
 }


### PR DESCRIPTION
the exit code will still be non-zero, but we'll get the output too, which is usually better than nothing.