### PR TITLE
API-1835: sampleoperator: refactor controllers

### DIFF
--- a/pkg/sampleoperator/sampleapplyconfiguration/controllers.go
+++ b/pkg/sampleoperator/sampleapplyconfiguration/controllers.go
@@ -6,8 +6,11 @@ import (
 	"strconv"
 	"time"
 
+	configv1 "github.com/openshift/api/config/v1"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -18,13 +21,55 @@ import (
 	"k8s.io/klog/v2"
 )
 
+func newFailureGeneratorController(
+	instanceName string,
+	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
+	eventRecorder events.Recorder) factory.Controller {
+
+	syncFn := func(ctx context.Context, _ factory.SyncContext) error {
+		eventRecorder.Event("must", "event")
+		_, err := kubeInformersForNamespaces.ConfigMapLister().ConfigMaps("openshift-authentication").Get("fail-check")
+		if apierrors.IsNotFound(err) {
+			fmt.Printf("forced-failure not required\n")
+			return nil
+		}
+		if err != nil {
+			fmt.Printf("failed to get configmap: %v\n", err)
+			return err
+		}
+		fmt.Printf("forcing an error\n")
+		return fmt.Errorf("fail the process")
+	}
+
+	return factory.New().
+		WithSync(syncFn).
+		WithControllerInstanceName(factory.ControllerInstanceName(instanceName, "FailureGenerator")).
+		ToController("FailureGenerator", eventRecorder.WithComponentSuffix(factory.ControllerInstanceName(instanceName, "FailureGenerator")))
+}
+
+func newIngressCreatorController(
+	instanceName string,
+	configClient configclient.Interface,
+	eventRecorder events.Recorder) factory.Controller {
+
+	syncFn := func(ctx context.Context, _ factory.SyncContext) error {
+		_, err := configClient.ConfigV1().Ingresses().Create(ctx, &configv1.Ingress{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}, metav1.CreateOptions{})
+		return err
+	}
+
+	return factory.New().
+		WithSync(syncFn).
+		WithControllerInstanceName(factory.ControllerInstanceName(instanceName, "IngressCreator")).
+		ToController("IngressCreator", eventRecorder.WithComponentSuffix(factory.ControllerInstanceName(instanceName, "IngressCreator")))
+}
+
 type demoController struct {
 	controllerInstanceName string
 	kubeClient             kubernetes.Interface
 	kubeConfigMapLister    corev1listers.ConfigMapLister
 }
 
-func NewDemoController(
+func newDemoController(
 	instanceName string,
 	kubeClient kubernetes.Interface,
 	kubeConfigMapInformer corev1informers.ConfigMapInformer,

--- a/test-data/apply-configuration/eventing-01/expected-output/Configuration/Create/cluster-scoped-resources/config.openshift.io/ingresses/002-body-cluster.yaml
+++ b/test-data/apply-configuration/eventing-01/expected-output/Configuration/Create/cluster-scoped-resources/config.openshift.io/ingresses/002-body-cluster.yaml
@@ -2,7 +2,7 @@ apiVersion: config.openshift.io/v1
 kind: Ingress
 metadata:
   annotations:
-    synthetic.mom.openshift.io/controller-instance-name: sample-operator-ingress-creator
+    synthetic.mom.openshift.io/controller-instance-name: sample-operator-IngressCreator
   creationTimestamp: null
   name: cluster
 spec:

--- a/test-data/apply-configuration/test-basic-call/expected-output/Configuration/Create/cluster-scoped-resources/config.openshift.io/ingresses/002-body-cluster.yaml
+++ b/test-data/apply-configuration/test-basic-call/expected-output/Configuration/Create/cluster-scoped-resources/config.openshift.io/ingresses/002-body-cluster.yaml
@@ -2,7 +2,7 @@ apiVersion: config.openshift.io/v1
 kind: Ingress
 metadata:
   annotations:
-    synthetic.mom.openshift.io/controller-instance-name: sample-operator-ingress-creator
+    synthetic.mom.openshift.io/controller-instance-name: sample-operator-IngressCreator
   creationTimestamp: null
   name: cluster
 spec:

--- a/test-data/apply-configuration/test-controller-name/expected-output/Configuration/Create/cluster-scoped-resources/config.openshift.io/ingresses/002-body-cluster.yaml
+++ b/test-data/apply-configuration/test-controller-name/expected-output/Configuration/Create/cluster-scoped-resources/config.openshift.io/ingresses/002-body-cluster.yaml
@@ -2,7 +2,7 @@ apiVersion: config.openshift.io/v1
 kind: Ingress
 metadata:
   annotations:
-    synthetic.mom.openshift.io/controller-instance-name: sample-operator-ingress-creator
+    synthetic.mom.openshift.io/controller-instance-name: sample-operator-IngressCreator
   creationTimestamp: null
   name: cluster
 spec:

--- a/test-data/apply-configuration/test-controller-name/test.yaml
+++ b/test-data/apply-configuration/test-controller-name/test.yaml
@@ -1,7 +1,7 @@
 binaryName: ./sample-operator
 testName: test controller name
 controllers:
-  - "sample-operator-ingress-creator"
+  - "sample-operator-IngressCreator"
 description: >
   Test if specifying a controller name works.
 testType: ApplyConfiguration

--- a/test-data/apply-configuration/test-forced-error/expected-output/Configuration/Create/cluster-scoped-resources/config.openshift.io/ingresses/002-body-cluster.yaml
+++ b/test-data/apply-configuration/test-forced-error/expected-output/Configuration/Create/cluster-scoped-resources/config.openshift.io/ingresses/002-body-cluster.yaml
@@ -2,7 +2,7 @@ apiVersion: config.openshift.io/v1
 kind: Ingress
 metadata:
   annotations:
-    synthetic.mom.openshift.io/controller-instance-name: sample-operator-ingress-creator
+    synthetic.mom.openshift.io/controller-instance-name: sample-operator-IngressCreator
   creationTimestamp: null
   name: cluster
 spec:


### PR DESCRIPTION
I’m planning to add more controllers to test double creation, deletion, and updates. 
For example: https://github.com/openshift/multi-operator-manager/pull/43/commits/5dceb6a8792d24de87c8ed3318865af37ec5998f

Having all controllers in one place improves maintainability.