### PR TITLE
API-1835: pkg/applyconfiguration/execer.go: allow passing env var to the process

### DIFF
--- a/pkg/applyconfiguration/execer.go
+++ b/pkg/applyconfiguration/execer.go
@@ -13,23 +13,27 @@ import (
 	"time"
 )
 
-type ApplyConfigurationFlagValues struct {
+type ApplyConfigurationOptions struct {
 	InputDirectory  string
 	OutputDirectory string
 	Now             time.Time
 	Controllers     []string
+
+	// Env specifies the environment of the process.
+	// Each entry is of the form "key=value".
+	Env []string
 }
 
 // ExecApplyConfiguration takes a binaryPath, inputDir, and desiredOutputDir and runs the binary
 // It then reads the result directory and returns the result.
-func ExecApplyConfiguration(ctx context.Context, binaryPath string, flagValues ApplyConfigurationFlagValues) (libraryapplyconfiguration.ApplyConfigurationResult, error) {
+func ExecApplyConfiguration(ctx context.Context, binaryPath string, options ApplyConfigurationOptions) (libraryapplyconfiguration.ApplyConfigurationResult, error) {
 	// the cmd.Wait() closes these output files.
-	stdoutFilename := filepath.Join(flagValues.OutputDirectory, "stdout.log")
+	stdoutFilename := filepath.Join(options.OutputDirectory, "stdout.log")
 	stdoutFile, err := os.OpenFile(stdoutFilename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
 	if err != nil {
 		return nil, fmt.Errorf("unable to open stdout.log: %w", err)
 	}
-	stderrFilename := filepath.Join(flagValues.OutputDirectory, "stderr.log")
+	stderrFilename := filepath.Join(options.OutputDirectory, "stderr.log")
 	stderrFile, err := os.OpenFile(stderrFilename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
 	if err != nil {
 		return nil, fmt.Errorf("unable to open stderr.log: %w", err)
@@ -37,14 +41,14 @@ func ExecApplyConfiguration(ctx context.Context, binaryPath string, flagValues A
 
 	args := []string{
 		"apply-configuration",
-		"--input-dir", flagValues.InputDirectory,
-		"--output-dir", flagValues.OutputDirectory,
+		"--input-dir", options.InputDirectory,
+		"--output-dir", options.OutputDirectory,
 	}
-	if !flagValues.Now.IsZero() {
-		args = append(args, "--now", flagValues.Now.Format(time.RFC3339))
+	if !options.Now.IsZero() {
+		args = append(args, "--now", options.Now.Format(time.RFC3339))
 	}
-	if len(flagValues.Controllers) > 0 {
-		args = append(args, "--controllers", strings.Join(flagValues.Controllers, ","))
+	if len(options.Controllers) > 0 {
+		args = append(args, "--controllers", strings.Join(options.Controllers, ","))
 	}
 
 	// TODO prove that the timeout works if the process captures sig-int
@@ -54,6 +58,7 @@ func ExecApplyConfiguration(ctx context.Context, binaryPath string, flagValues A
 	cmd := exec.CommandContext(processCtx, binaryPath, args...)
 	cmd.Stdout = stdoutFile
 	cmd.Stderr = stderrFile
+	cmd.Env = options.Env
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("failed to start process: %w", err)
 	}
@@ -68,18 +73,18 @@ func ExecApplyConfiguration(ctx context.Context, binaryPath string, flagValues A
 				utilruntime.HandleError(err)
 			}
 			return libraryapplyconfiguration.NewApplyConfigurationResultFromDirectory(
-				os.DirFS(flagValues.OutputDirectory),
-				flagValues.OutputDirectory,
+				os.DirFS(options.OutputDirectory),
+				options.OutputDirectory,
 				fmt.Errorf("failed to wait for process %v: %w stderr: %v", cmd, err, string(exitErr.Stderr)))
 		}
 		return libraryapplyconfiguration.NewApplyConfigurationResultFromDirectory(
-			os.DirFS(flagValues.OutputDirectory),
-			flagValues.OutputDirectory,
+			os.DirFS(options.OutputDirectory),
+			options.OutputDirectory,
 			fmt.Errorf("failed to wait for process: %w", err))
 	}
 
 	return libraryapplyconfiguration.NewApplyConfigurationResultFromDirectory(
-		os.DirFS(flagValues.OutputDirectory),
-		flagValues.OutputDirectory,
+		os.DirFS(options.OutputDirectory),
+		options.OutputDirectory,
 		nil)
 }

--- a/pkg/test/testapplyconfiguration/tester.go
+++ b/pkg/test/testapplyconfiguration/tester.go
@@ -189,13 +189,13 @@ func (o *TestOptions) runTest(ctx context.Context, preservePolicy PreservePolicy
 	}
 
 	inputDir := filepath.Join(o.TestDirectory, "input-dir")
-	args := applyconfiguration.ApplyConfigurationFlagValues{
+	options := applyconfiguration.ApplyConfigurationOptions{
 		InputDirectory:  inputDir,
 		OutputDirectory: o.OutputDirectory,
 		Now:             o.Description.Now.Time,
 		Controllers:     o.Description.Controllers,
 	}
-	actualResult, execErr := applyconfiguration.ExecApplyConfiguration(ctx, o.Description.BinaryName, args)
+	actualResult, execErr := applyconfiguration.ExecApplyConfiguration(ctx, o.Description.BinaryName, options)
 	endTime := now()
 	currJunit.Duration = endTime.Sub(startTime).Round(1 * time.Second).Seconds()
 


### PR DESCRIPTION
for example, i will be able to specify `IMAGE_OAUTH_SERVER` for the oauth-server