### PR TITLE
API-1835: update the docker image to be consistent with 4.22 release

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.22-openshift-4.18
+  tag: rhel-9-release-golang-1.24-openshift-4.22

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.22 AS builder
 WORKDIR /go/src/github.com/openshift/multi-operator-manager
 COPY . .
 RUN make
 
-FROM registry.ci.openshift.org/ocp/4.18:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/multi-operator-manager/multi-operator-manager /usr/bin/
 ENTRYPOINT ["/usr/bin/multi-operator-manager"]
 LABEL io.k8s.display-name="OpenShift Multi Operator Manager" \


### PR DESCRIPTION
At some point we need to add this repo to the ART.